### PR TITLE
Fix a non-tail call in the dispatcher.

### DIFF
--- a/client_unix/xs_client_unix.ml
+++ b/client_unix/xs_client_unix.ml
@@ -218,7 +218,6 @@ module Client = functor(IO: IO with type 'a t = 'a) -> struct
             | Some w -> Watcher.put w path
             | None -> if not(startswith auto_watch_prefix token) then enqueue_watch t (path, token)
             end;
-            dispatcher t
           | _ ->
             handle_exn t Malformed_watch_event
         end;


### PR DESCRIPTION
A watch event would trigger a non-tail-recursive call, which would
blow the default 10M stack after ~170000 watches.

Signed-off-by: Jon Ludlam <jonathan.ludlam@eu.citrix.com>