### PR TITLE
Terminating replacements for transaction function

### DIFF
--- a/client_unix/xs_client_unix.ml
+++ b/client_unix/xs_client_unix.ml
@@ -406,5 +406,11 @@ module Client = functor(IO: IO with type 'a t = 'a) -> struct
     with Eagain when (attempts > 1) ->
       transaction_attempts (attempts-1) client f
 
+  (** Deprecated: retries for ever on repeated Eagain *)
+  let rec transaction client f =
+    let (h, result) = _transaction_leave_open client f in
+    try _commit h result
+    with Eagain -> transaction client f
+
 end
 

--- a/client_unix/xs_client_unix.ml
+++ b/client_unix/xs_client_unix.ml
@@ -386,15 +386,25 @@ module Client = functor(IO: IO with type 'a t = 'a) -> struct
     in
     t
 
-  let rec transaction client f =
+  let _transaction_leave_open client f =
     let tid = rpc "transaction_start" (Xs_handle.no_transaction client) Request.Transaction_start Unmarshal.int32 in
     let h = Xs_handle.transaction client tid in
     let result = f h in
-    try
-      let res' = rpc "transaction_end" h (Request.Transaction_end true) Unmarshal.string in
-      if res' = "OK" then result else raise (Error (Printf.sprintf "Unexpected transaction result: %s" res'))
-    with Eagain ->
-      transaction client f
+    (h, result)
+
+  let _commit h result =
+    let res' = rpc "transaction_end" h (Request.Transaction_end true) Unmarshal.string in
+    if res' = "OK" then result else raise (Error (Printf.sprintf "Unexpected transaction result: %s" res'))
+
+  let transaction_one_try client f =
+    let (h, result) = _transaction_leave_open client f in
+    _commit h result
+
+  let rec transaction_attempts attempts client f =
+    let (h, result) = _transaction_leave_open client f in
+    try _commit h result
+    with Eagain when (attempts > 1) ->
+      transaction_attempts (attempts-1) client f
 
 end
 

--- a/client_unix/xs_client_unix.mli
+++ b/client_unix/xs_client_unix.mli
@@ -66,9 +66,16 @@ module Client : functor(IO: IO) -> sig
   val immediate : client -> (handle -> 'a IO.t) -> 'a IO.t
   (** Access xenstore with individual operations. *)
 
-  val transaction : client -> (handle -> 'a IO.t) -> 'a IO.t
+  val transaction_one_try : client -> (handle -> 'a IO.t) -> 'a IO.t
   (** Access xenstore with a single transaction.  On conflict the
-      operation will be repeated. *)
+      Eagain error will not be handled but will be passed up to the
+      caller. *)
+
+  val transaction_attempts : int -> client -> (handle -> 'a IO.t) -> 'a IO.t
+  (** Access xenstore with a single transaction.  On conflict the
+      operation may be attempted again, up to a total of (max attempts 1)
+      attempts. If the last of those fails with a conflict, the Eagain
+      exception will be raised to the caller. *)
 
   val wait : client -> (handle -> 'a IO.t) -> 'a Task.u
   (** Wait for some condition to become true and return a value.  The

--- a/client_unix/xs_client_unix.mli
+++ b/client_unix/xs_client_unix.mli
@@ -77,6 +77,12 @@ module Client : functor(IO: IO) -> sig
       attempts. If the last of those fails with a conflict, the Eagain
       exception will be raised to the caller. *)
 
+  val transaction : client -> (handle -> 'a IO.t) -> 'a IO.t
+  (** DEPRECATED!
+      Access xenstore with a single transaction.  On conflict the
+      operation will be repeated INDEFINITELY, with no guarantee
+      of eventual success or termination. *)
+
   val wait : client -> (handle -> 'a IO.t) -> 'a Task.u
   (** Wait for some condition to become true and return a value.  The
       function argument should throw Eagain if the condition is not


### PR DESCRIPTION
The Xs_client_unix.transaction function would retry for ever if some
client were to keep making writes conflicting with the transaction.

This commit replaces `transaction` with `transaction_one_try` and
`transaction_attempts` which will make only a limited number of
attempts before abandoning the transaction on conflict and passing
the Eagain exception up to the caller.