### PR TITLE
Don't link PPX rewriters into clients

### DIFF
--- a/core/jbuild
+++ b/core/jbuild
@@ -2,7 +2,7 @@
  ((name xenstore)
   (public_name xenstore)
   (wrapped false)
-  (libraries (cstruct cstruct.ppx))
+  (libraries (cstruct))
   (preprocess (pps (cstruct.ppx)))
 ))
 


### PR DESCRIPTION
The package cstruct.ppx contains helper functions for the PPX rewriter itself. Linking this code into applications makes them larger and also brings in a dependency on compiler-libs which pollutes the global module namespace with names like Types.

See mirage/mirage-www#556

Signed-off-by: David Scott <dave@recoil.org>