### PR TITLE
xenstore.opam: require cstruct >= 3.2.0

### DIFF
--- a/xenstore.opam
+++ b/xenstore.opam
@@ -21,7 +21,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "3.2.0"}
   "ppx_cstruct" {build}
   "ppx_tools" {build}
   "lwt"


### PR DESCRIPTION
The to_bytes function used in this version of xenstore has been introduced in cstruct 3.2.0.