### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/xenstore.opam
+++ b/xenstore.opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-xenstore/"
 bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.2.0"}
   "ppx_cstruct" {>= "3.2.0"}
   "lwt"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.