### PR TITLE
Fix crash if watch quota is exceeded

### DIFF
--- a/client_lwt/xs_client_lwt.ml
+++ b/client_lwt/xs_client_lwt.ml
@@ -403,9 +403,11 @@ module Client = functor(IO: IO with type 'a t = 'a Lwt.t) -> struct
       >>= function
       | true -> return ()
       | false ->
-        adjust_paths ()
-        >>= fun () ->
-        loop ()
+        Lwt.try_bind adjust_paths loop
+          (fun ex ->
+             wakeup_exn wakener ex;
+             Lwt.return_unit
+          )
     in
     Lwt.async (fun () ->
         finally loop


### PR DESCRIPTION
1. Don't try to unwatch watches that we never watched.
2. Return any error adding watches to the caller instead of crashing.

Fixes #43.