### PR TITLE
Add License to opam metadata

### DIFF
--- a/xenstore.opam
+++ b/xenstore.opam
@@ -10,6 +10,7 @@ authors: [
 homepage: "https://github.com/mirage/ocaml-xenstore"
 doc: "https://mirage.github.io/ocaml-xenstore/"
 bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}


### PR DESCRIPTION
Saw this was missing when looking at upstream packages used in the xapi project.

The metadata for the versions published in opam-repository could be changed as well, as I don't see the license having changed.