### PR TITLE
dune: require at least 2.7

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.7)
 
 (name xenstore)
 

--- a/xenstore.opam
+++ b/xenstore.opam
@@ -27,13 +27,14 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/mirage/ocaml-xenstore"
 bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.13.0"}
   "ounit2" {>= "2.2.2"}
   "lwt" {>= "4.5.0"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
This is the minimum version that generates non-problematic opam metadata